### PR TITLE
Add Qt5/PyQt5 acknowledgement to title bar.

### DIFF
--- a/main/PyQtGUI/gui/GUI.py
+++ b/main/PyQtGUI/gui/GUI.py
@@ -195,7 +195,7 @@ class MainWindow(QMainWindow):
         self.factory = factory
         self.fit_factory = fit_factory
 
-        self.setWindowTitle("CutiePie(QtPy) - It's not a bug, it's a feature (cit.)")
+        self.setWindowTitle("CutiePie(QtPy) - It's not a bug, it's a feature (cit.) Qt5 and PyQty5 used under open source terms.")
         self.setMouseTracking(True)
 
 


### PR DESCRIPTION
Sadly the splash screen does not stay up long enough on windows (or at least my windows laptop) to be visible so put the QT5 acknowledgement in the title bar.