### PR TITLE
Bookworm

### DIFF
--- a/main/PyQtGUI/gui/GUI.py
+++ b/main/PyQtGUI/gui/GUI.py
@@ -9,6 +9,7 @@ from copy import copy, deepcopy
 import pandas as pd
 import numpy as np
 import logging, logging.handlers
+import CPyConverter as cpy
 
 
 # import importlib

--- a/main/PyQtGUI/gui/GUI.py
+++ b/main/PyQtGUI/gui/GUI.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3os
 # import modules and packages
+
 import sys, os, ast
 import logging, copy, cv2
 import threading, time, math, re
@@ -8,6 +9,7 @@ from copy import copy, deepcopy
 import pandas as pd
 import numpy as np
 import logging, logging.handlers
+
 
 # import importlib
 # import io, pickle, traceback, sys, os, subprocess, ast, csv, gzip
@@ -76,7 +78,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 import matplotlib.text as mtext
 
-import CPyConverter as cpy
+
 
 # List of implementation topics
 # 0) Class definition

--- a/main/PyQtGUI/gui/Main.py
+++ b/main/PyQtGUI/gui/Main.py
@@ -2,6 +2,7 @@
 import io
 import re
 import sys, os, platform
+
 cwd = os.getcwd()
 
 #  Sadly it seems that environment variables sent in via setenv
@@ -15,6 +16,8 @@ libdir = mydir + '/../lib'
 sys.path.append(libdir)
 scriptdir = mydir + '/../Script'   # SpecTcl install
 sys.path.append(scriptdir)
+
+import CPyConverter as cpy
 
 #  If we are in windows, we need to allow DLL's to be loaded
 #  from our script dir so:


### PR DESCRIPTION
Do what's needed to get CutiePie to runo n BOokworm (and bullseye for that matter:
* SInce we have mismatched version of the debian and PyQt5 sip package we need to pull in CPyConverter before pulling in any PyQt5 packages.  So added an import for that in Main.py after the paths are set but before any PyQt5 imports are done.   Note that import in Gui.py is still needed since imported namespaces are local to the module....however Python has a registry of imported modules so there's no actual reload of the .so and no actual load of the sip in PyQt5 when those modules are loaded.