### PR TITLE
fix(gui,rest): runtime port reconfigure + health; prevent port leaks via FD close; env-port overrides

### DIFF
--- a/main/PyQtGUI/gui/Main.py
+++ b/main/PyQtGUI/gui/Main.py
@@ -3,6 +3,19 @@ import io
 import re
 import sys, os, platform
 
+# Bashir: --- drop any inherited file descriptors >=3 (prevents holding REST/Mirror after parent exit) ---
+import os
+try:
+    maxfd = os.sysconf("SC_OPEN_MAX")
+except Exception:
+    maxfd = 1024
+try:
+    os.closerange(3, maxfd)
+except Exception:
+    pass
+# --- end drop inherited FDs ---
+
+
 cwd = os.getcwd()
 
 #  Sadly it seems that environment variables sent in via setenv
@@ -46,7 +59,8 @@ if "USERDIR" in os.environ:
     sys.path.append(os.environ["USERDIR"])
     print("The .py user-based files are in ",os.environ["USERDIR"])
 # Check if the user-based files are in the current working directory.
-elif os.path.exists(os.path.join(cwd, "fit_skel_creator.py")) and os.path.exists(os.path.join(cwd, "algo_skel_creator.py")):
+elif os.path.exists(os.path.join(cwd, "fit_alpha1_creator.py")) and os.path.exists(os.path.join(cwd, "fit_alpha2_creator.py")) \
+and os.path.exists(os.path.join(cwd, "algo_skel_creator.py")):
     print("The .py user-based files are in the current working directory.")
     sys.path.append(cwd)
 
@@ -64,6 +78,9 @@ from GUI import MainWindow
 import fit_factory
 # skeleton for user-based FIT implementation
 import fit_skel_creator
+import fit_alpha1_creator
+import fit_alpha2_creator
+import fit_alpha3_creator
 # already implemented examples
 import fit_gaus_creator
 import fit_exp_creator
@@ -71,6 +88,7 @@ import fit_p1_creator
 import fit_p2_creator
 import fit_gp1_creator
 import fit_gp2_creator
+
 
 import algo_factory
 # skeleton for user-based ML implementation
@@ -142,6 +160,25 @@ config_fit_skel = {
     'param_3': 10
 }
 
+config_fit_alph1 = {
+    'param_1': 1,
+    'param_2': 1,
+    'param_3': 10
+}
+
+config_fit_alph2 = {
+    'param_1': 1,
+    'param_2': 1,
+    'param_3': 10
+}
+
+config_fit_alph3 = {
+    'param_1': 1,
+    'param_2': 1,
+    'param_3': 10
+}
+
+
 
 #######################################
 ##  ML
@@ -190,7 +227,10 @@ fitfactory.register_builder('Pol1', fit_p1_creator.Pol1FitBuilder(), config_fit_
 fitfactory.register_builder('Pol2', fit_p2_creator.Pol2FitBuilder(), config_fit_p2)
 fitfactory.register_builder('G+Pol1', fit_gp1_creator.GPol1FitBuilder(), config_fit_gp1)
 fitfactory.register_builder('G+Pol2', fit_gp2_creator.GPol2FitBuilder(), config_fit_gp2)
-fitfactory.register_builder('Skeleton', fit_skel_creator.SkelFitBuilder(), config_fit_skel)
+fitfactory.register_builder('AlphaEMG1', fit_alpha1_creator.AlphaEMG1FitBuilder(), config_fit_alph1)
+fitfactory.register_builder('AlphaEMG2', fit_alpha2_creator.AlphaEMG2FitBuilder(), config_fit_alph2)
+fitfactory.register_builder('AlphaEMG3', fit_alpha3_creator.AlphaEMG3FitBuilder(), config_fit_alph3)
+# fitfactory.register_builder('Skeleton', fit_skel_creator.SkelFitBuilder(), config_fit_skel)
 
 # ML Algorithm registration
 algofactory.register_builder('Skeleton', algo_skel_creator.SkelAlgoBuilder(), config_algo_skel)

--- a/main/PyQtGUI/gui/PyREST.py
+++ b/main/PyQtGUI/gui/PyREST.py
@@ -10,6 +10,14 @@ class PyREST:
         self.server = server
         self.rest = rest
         self.logger = loggerMain
+    
+
+    #### Bashir added so the REST client can switch to whatever they type in the Connect window #################
+    def reconfigure(self, server, rest):
+        self.server = str(server).strip()
+        self.rest = str(rest).strip()
+        # self.logger.info("PyREST reconfigured to http://%s:%s", self.server, self.rest)
+    ##################################################################################
 
     ########################################
     ## Parameter requests
@@ -979,6 +987,9 @@ class PyREST:
     
     def sendRequest(self, url):
         try:
+            ### Bashur added #################
+            self.logger.debug("REST GET %s", url)   # <-- add
+            ##################################
             status, content = httplib2.Http().request(url, method="GET") # SpecTclREST only takes GET methods.
             #May have other bad keywords
             badKeyWords = ["bad parameter", "Invalid gate"]
@@ -992,8 +1003,8 @@ class PyREST:
             self.logger.error('sendRequest -- check Server/User/REST Port/Mirror Port')
             return None
     
-
-    #check if url is valid
+    ''' # Bashir commented out
+     #check if url is valid
     def checkSpecTclREST(self):
         url = "http://"+self.server+":"+self.rest+"/spectcl"
         try:
@@ -1001,4 +1012,19 @@ class PyREST:
             return True
         except Exception :
             return False
+    '''
+
+    def checkSpecTclREST(self):
+        url = f"http://{self.server}:{self.rest}/spectcl/spectrum/list?filter=*"
+        try:
+            status, content = httplib2.Http().request(url, method="GET")
+            data = json.loads(content.decode())
+            ok = isinstance(data, dict) and data.get("status") == "OK"
+            print(f"[PyREST] REST health {'OK' if ok else 'FAIL'} via {url}", flush=True)  # <-- add
+            return ok
+        except Exception:
+            print(f"[PyREST] REST health FAIL via {url} (exception)", flush=True)          # <-- add
+            return False
+
+
             


### PR DESCRIPTION
#12 and beyond

Problem
- Changing ports in the Connect window could not switch the REST client.
- After SpecTcl exited (while GUI stayed open), REST/Mirror ports remained in LISTEN
  because the child GUI processes inherited the sockets.
- Switching server ports required editing SpecTclInit.tcl.

Changes
- Script/PyREST.py
  - add PyREST.reconfigure(server, rest) to retarget the client at runtime.
  - add checkSpecTclREST() health probe (GET /spectcl/spectrum/list?filter=*, JSON parse)
    with an explicit OK/FAIL print that includes the URL.
- Script/GUI.py (connectShMem)
  - reuse existing PyREST instance when changing host/port (calls .reconfigure()).
  - gate REST thread startup behind a successful health check to avoid noisy failures.
- Main.py
  - at process start, close inherited FDs ≥ 3 (os.closerange) to prevent holding sockets.
- bin/_CutiePie
  - replace entrypoint with a tiny Python wrapper that closes FDs ≥ 3, then execs
    the original ELF renamed to _CutiePie.real.
- SpecTclInit.tcl (mySpecTclDev tree)
  - add a final override *after* DAQService branch:
      if RESTport/MIRRORport are set in env, force HTTPDPort/MirrorPort to those values.
      